### PR TITLE
added spring repo to resolve mvn resolve error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,12 +31,12 @@
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
 
-  <repositories>
+ <repositories>
     <!-- Including for fontawesome -->
     <repository>
-      <id>spring-repo</id>
-      <name>Spring Repository</name>
-      <url>https://repo.spring.io/plugins-release/</url>
+      <id>fontawesomefx-repo</id>
+      <name>FontAwesome Repository</name>
+      <url>https://bintray.com/jerady/maven/FontAwesomeFX</url>
     </repository>
   </repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,15 @@
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
 
+  <repositories>
+    <!-- Including for fontawesome -->
+    <repository>
+      <id>spring-repo</id>
+      <name>Spring Repository</name>
+      <url>https://repo.spring.io/plugins-release/</url>
+    </repository>
+  </repositories>
+
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -93,13 +102,13 @@
       <version>3.1.1</version>
       <type>maven-plugin</type>
     </dependency>
-    
+
     <dependency>
       <groupId>de.jensd</groupId>
       <artifactId>fontawesomefx-commons</artifactId>
       <version>8.15</version>
     </dependency>
-    
+
     <dependency>
       <groupId>de.jensd</groupId>
       <artifactId>fontawesomefx-fontawesome</artifactId>
@@ -144,7 +153,7 @@
           <failOnError>${maven-dependency-check.failOnError}</failOnError>
           <failBuildOnCVSS>${maven-dependency-check.failBuildOnCVSS}</failBuildOnCVSS>
           <outputDirectory>target/site</outputDirectory>
-          <!--suppressionFile>${project.basedir}/dependency-check-report_suppressions.xml</suppressionFile-->
+          <!--suppressionFile>${project.basedir}/dependency-check-report_suppressions.xml</suppressionFile -->
         </configuration>
         <executions>
           <execution>
@@ -184,7 +193,7 @@
           <failOnError>${maven-dependency-check.failOnError}</failOnError>
           <failBuildOnCVSS>${maven-dependency-check.failBuildOnCVSS}</failBuildOnCVSS>
           <outputDirectory>target/site</outputDirectory>
-          <!--suppressionFile>${project.basedir}/dependency-check-report_suppressions.xml</suppressionFile-->
+          <!--suppressionFile>${project.basedir}/dependency-check-report_suppressions.xml</suppressionFile -->
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
when building with mvn e.g. 'mvn install' the fontawesome libs cannot be resolved. 
The referenced libraries are not in the central repo, but in spring repo: https://mvnrepository.com/artifact/de.jensd/fontawesomefx-fontawesome?repo=springio-plugins-release
the versions in central are not compatible with java 8. seems like we have to include the spring repo