### PR TITLE
#74: Fixed a bug where the "add note" dialog did not appear at switching

### DIFF
--- a/src/main/java/de/doubleslash/keeptime/controller/Controller.java
+++ b/src/main/java/de/doubleslash/keeptime/controller/Controller.java
@@ -92,9 +92,6 @@ public class Controller {
       }
 
       currentWork.setEndTime(workEnd);
-      if (currentWork.getNotes().isEmpty()) {
-         currentWork.setNotes("- No notes -");
-      }
 
       final String time = DateFormatter
             .secondsToHHMMSS(Duration.between(currentWork.getStartTime(), currentWork.getEndTime()).getSeconds());

--- a/src/main/java/de/doubleslash/keeptime/view/ProjectReport.java
+++ b/src/main/java/de/doubleslash/keeptime/view/ProjectReport.java
@@ -16,7 +16,6 @@
 
 package de.doubleslash.keeptime.view;
 
-import static de.doubleslash.keeptime.view.ReportController.EMPTY_NOTE;
 import static de.doubleslash.keeptime.view.ReportController.NOTE_DELIMETER;
 
 import java.lang.invoke.MethodHandles;
@@ -42,7 +41,7 @@ public class ProjectReport {
 
    public void appendToWorkNotes(final String currentWorkNote) {
       this.numberOfNotes++;
-      if (!currentWorkNote.equals(EMPTY_NOTE)) {
+      if (!currentWorkNote.isEmpty()) {
          if (this.numberOfNotes > 1) {
             this.sb.append(NOTE_DELIMETER);
          }

--- a/src/main/java/de/doubleslash/keeptime/view/ReportController.java
+++ b/src/main/java/de/doubleslash/keeptime/view/ReportController.java
@@ -148,7 +148,8 @@ public class ReportController {
                      setGraphic(null);
                      setText(null);
                   } else {
-                     final Text text = new Text(item.getNotes());
+                     final String notes = item.getNotes();
+                     final Text text = new Text(notes.isEmpty() ? EMPTY_NOTE : notes);
                      text.wrappingWidthProperty().bind(noteColumn.widthProperty().subtract(35));
                      text.setUnderline(item.isUnderlined());
                      this.setGraphic(text);

--- a/src/test/java/de/doubleslash/keeptime/view/ProjectReportTest.java
+++ b/src/test/java/de/doubleslash/keeptime/view/ProjectReportTest.java
@@ -40,7 +40,7 @@ public class ProjectReportTest {
    @Test
    public void testAppendToWorkNotes() {
       this.uut.appendToWorkNotes("note 1 ");
-      this.uut.appendToWorkNotes(ReportController.EMPTY_NOTE);
+      this.uut.appendToWorkNotes("");
       this.uut.appendToWorkNotes("note 2 ");
       final String expected = "note 1; note 2";
       assertEquals(expected, this.uut.getNotes(false));
@@ -49,7 +49,7 @@ public class ProjectReportTest {
    @Test
    public void testAppendToWorkNotesAddNumberOfNotes() {
       this.uut.appendToWorkNotes("note 1 ");
-      this.uut.appendToWorkNotes(ReportController.EMPTY_NOTE);
+      this.uut.appendToWorkNotes("");
       this.uut.appendToWorkNotes("note 2 ");
       final String expected = "3 Notes: note 1; note 2";
       assertEquals(expected, this.uut.getNotes(true));
@@ -70,8 +70,8 @@ public class ProjectReportTest {
       this.uut = new ProjectReport(4);
       this.uut.appendToWorkNotes("note 1");
       this.uut.appendToWorkNotes("note 2");
-      this.uut.appendToWorkNotes(ReportController.EMPTY_NOTE);
-      this.uut.appendToWorkNotes(ReportController.EMPTY_NOTE);
+      this.uut.appendToWorkNotes("");
+      this.uut.appendToWorkNotes("");
       final String expected = "4 Notes: note 1; note 2";
       assertEquals(expected, this.uut.getNotes(true));
    }

--- a/src/test/java/de/doubleslash/keeptime/view/ProjectReportTest.java
+++ b/src/test/java/de/doubleslash/keeptime/view/ProjectReportTest.java
@@ -30,6 +30,8 @@ public class ProjectReportTest {
    /** The slf4j-logger for this class. */
    private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
+   private static final String EMPTY_NOTE = "";
+
    private ProjectReport uut;
 
    @Before
@@ -40,7 +42,7 @@ public class ProjectReportTest {
    @Test
    public void testAppendToWorkNotes() {
       this.uut.appendToWorkNotes("note 1 ");
-      this.uut.appendToWorkNotes("");
+      this.uut.appendToWorkNotes(EMPTY_NOTE);
       this.uut.appendToWorkNotes("note 2 ");
       final String expected = "note 1; note 2";
       assertEquals(expected, this.uut.getNotes(false));
@@ -49,7 +51,7 @@ public class ProjectReportTest {
    @Test
    public void testAppendToWorkNotesAddNumberOfNotes() {
       this.uut.appendToWorkNotes("note 1 ");
-      this.uut.appendToWorkNotes("");
+      this.uut.appendToWorkNotes(EMPTY_NOTE);
       this.uut.appendToWorkNotes("note 2 ");
       final String expected = "3 Notes: note 1; note 2";
       assertEquals(expected, this.uut.getNotes(true));
@@ -70,8 +72,8 @@ public class ProjectReportTest {
       this.uut = new ProjectReport(4);
       this.uut.appendToWorkNotes("note 1");
       this.uut.appendToWorkNotes("note 2");
-      this.uut.appendToWorkNotes("");
-      this.uut.appendToWorkNotes("");
+      this.uut.appendToWorkNotes(EMPTY_NOTE);
+      this.uut.appendToWorkNotes(EMPTY_NOTE);
       final String expected = "4 Notes: note 1; note 2";
       assertEquals(expected, this.uut.getNotes(true));
    }


### PR DESCRIPTION
project after autosave.
The issue showed up because the autosave set the note to the EMPTY_NOTE
constant. When switching the current project it was only checked whether
the note is empty.
Now autosave leaves the note as an empty string and the EMPTY_NOTE
constant is only used for better visualization in the ProjectReport View
but not for storage.