### PR TITLE
Bugfix/#79 negative time calculation

### DIFF
--- a/src/main/java/de/doubleslash/keeptime/controller/Controller.java
+++ b/src/main/java/de/doubleslash/keeptime/controller/Controller.java
@@ -94,7 +94,7 @@ public class Controller {
       currentWork.setEndTime(workEnd);
 
       final String time = DateFormatter
-            .secondsToHHMMSS(Duration.between(currentWork.getStartTime(), currentWork.getEndTime()).getSeconds());
+            .secondsToHHMMSS(DateFormatter.getSecondsBewtween(currentWork.getStartTime(), currentWork.getEndTime()));
 
       LOG.info("Saving Work from '{}' to '{}' ({}) on project '{}' with notes '{}'", currentWork.getStartTime(),
             currentWork.getEndTime(), time, currentWork.getProject().getName(), currentWork.getNotes());

--- a/src/main/java/de/doubleslash/keeptime/controller/Controller.java
+++ b/src/main/java/de/doubleslash/keeptime/controller/Controller.java
@@ -350,7 +350,7 @@ public class Controller {
       long seconds = 0;
 
       for (final Work w : workItems) {
-         seconds += Duration.between(w.getStartTime(), w.getEndTime()).getSeconds();
+         seconds += DateFormatter.getSecondsBewtween(w.getStartTime(), w.getEndTime());
       }
 
       return seconds;

--- a/src/main/java/de/doubleslash/keeptime/view/ColorTimeLine.java
+++ b/src/main/java/de/doubleslash/keeptime/view/ColorTimeLine.java
@@ -19,6 +19,7 @@ package de.doubleslash.keeptime.view;
 import java.time.Duration;
 import java.util.List;
 
+import de.doubleslash.keeptime.common.DateFormatter;
 import de.doubleslash.keeptime.model.Work;
 import javafx.scene.canvas.Canvas;
 import javafx.scene.canvas.GraphicsContext;
@@ -40,7 +41,7 @@ public class ColorTimeLine {
       gc.fillRect(0, 0, canvas.getWidth(), canvas.getHeight());
       double currentX = 0;
       for (final Work w : workItems) {
-         final long workedSeconds = Duration.between(w.getStartTime(), w.getEndTime()).getSeconds();
+         final long workedSeconds = DateFormatter.getSecondsBewtween(w.getStartTime(), w.getEndTime());
          final double width = (double) workedSeconds / seconds * canvas.getWidth();
          final Color fill = w.getProject().getColor();
 

--- a/src/main/java/de/doubleslash/keeptime/view/ProjectsListViewController.java
+++ b/src/main/java/de/doubleslash/keeptime/view/ProjectsListViewController.java
@@ -158,7 +158,7 @@ public class ProjectsListViewController {
          final Label label = entry.getValue();
 
          final long seconds = model.getPastWorkItems().stream().filter(work -> work.getProject().getId() == p.getId())
-               .mapToLong(work -> Duration.between(work.getStartTime(), work.getEndTime()).getSeconds()).sum();
+               .mapToLong(work -> DateFormatter.getSecondsBewtween(work.getStartTime(), work.getEndTime())).sum();
          label.setText(DateFormatter.secondsToHHMMSS(seconds));
       }
    }

--- a/src/main/java/de/doubleslash/keeptime/view/ViewController.java
+++ b/src/main/java/de/doubleslash/keeptime/view/ViewController.java
@@ -291,9 +291,7 @@ public class ViewController {
          final LocalDateTime now = LocalDateTime.now();
          model.activeWorkItem.get().setEndTime(now); // FIXME not good to change model
 
-         final long currentWorkSeconds = Duration
-               .between(model.activeWorkItem.get().getStartTime(), model.activeWorkItem.get().getEndTime())
-               .getSeconds();
+         final long currentWorkSeconds = DateFormatter.getSecondsBewtween(model.activeWorkItem.get().getStartTime(), model.activeWorkItem.get().getEndTime());
          activeWorkSecondsProperty.set(currentWorkSeconds);
          final long todayWorkingSeconds = controller.calcTodaysWorkSeconds();
          final long todaySeconds = controller.calcTodaysSeconds();

--- a/src/test/java/de/doubleslash/keeptime/common/DateFormatterTest.java
+++ b/src/test/java/de/doubleslash/keeptime/common/DateFormatterTest.java
@@ -16,26 +16,31 @@
 
 package de.doubleslash.keeptime.common;
 
-import static org.junit.Assert.assertThat;
-
 import java.time.LocalDateTime;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import org.hamcrest.Matchers;
-import org.junit.Ignore;
 import org.junit.Test;
 
-@Ignore
+
 public class DateFormatterTest {
 
    @Test
-   public void zeroSecondsBetweenTest() {
+   public void durationShouldBePositiveWhenStartBeforeEndDate() {
       final LocalDateTime startDate = LocalDateTime.now();
-      final LocalDateTime endDate = startDate.plusNanos(10000);
+      final LocalDateTime endDate = startDate.plusSeconds(10);
 
       final long secondsBewtween = DateFormatter.getSecondsBewtween(startDate, endDate);
-      assertThat(secondsBewtween, Matchers.is(0l));
-
-      final long secondsBewtweenSwitched = DateFormatter.getSecondsBewtween(endDate, startDate);
-      assertThat(secondsBewtweenSwitched, Matchers.is(0l)); // why??
+      assertThat(secondsBewtween, Matchers.is(10l));
+   }
+   
+   @Test
+   public void durationShouldBePositiveWhenEndBeforeStartDate() {
+	   final LocalDateTime startDate = LocalDateTime.now();
+	   final LocalDateTime endDate = startDate.plusSeconds(10);
+	   
+	   
+	   final long secondsBewtweenSwitched = DateFormatter.getSecondsBewtween(endDate, startDate);
+	   assertThat(secondsBewtweenSwitched, Matchers.is(10l));
    }
 }


### PR DESCRIPTION
Fixes issue where time was calculated wrong in report for the whole project, when work items exist which have startTime after endTime.
Issue was in Controller.calcSeconds but I also adapted logic at the other places