### PR TITLE
PTBAS-737: using consistent english language now

### DIFF
--- a/src/main/java/de/doubleslash/keeptime/App.java
+++ b/src/main/java/de/doubleslash/keeptime/App.java
@@ -21,9 +21,11 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import de.doubleslash.keeptime.common.DateFormatter;
 import javafx.stage.Window;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -84,6 +86,8 @@ public class App extends Application {
    @Override
    public void init() throws Exception {
       LOG.info("Starting KeepTime.");
+      DateFormatter.setSystemLocale(Locale.getDefault());
+      Locale.setDefault(Locale.ENGLISH);
       final DefaultExceptionHandler defaultExceptionHandler = new DefaultExceptionHandler();
       defaultExceptionHandler.register();
 

--- a/src/main/java/de/doubleslash/keeptime/common/DateFormatter.java
+++ b/src/main/java/de/doubleslash/keeptime/common/DateFormatter.java
@@ -16,14 +16,22 @@
 
 package de.doubleslash.keeptime.common;
 
+import javafx.scene.control.DatePicker;
+import javafx.util.StringConverter;
+
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.time.format.FormatStyle;
+import java.util.Locale;
 
 public class DateFormatter {
    private static DateTimeFormatter dayDateFormatter = DateTimeFormatter.ofPattern("eeee dd.MM.yyyy");
    private static DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("HH:mm:ss");
+
+   private static Locale systemLocale = Locale.GERMAN;
 
    private DateFormatter() {
       throw new IllegalStateException("Utility class: DateFormatter");
@@ -55,4 +63,33 @@ public class DateFormatter {
       return localDateTime.format(timeFormatter);
    }
 
+   public static void setSystemLocale(Locale locale) {
+      systemLocale = locale;
+   }
+
+   public static Locale getSystemLocale() {
+      return systemLocale;
+   }
+
+   public static void applySystemLocaleOnDate(DatePicker datePicker) {
+      DateTimeFormatter formatter = DateTimeFormatter.ofLocalizedDate(FormatStyle.SHORT).withLocale(systemLocale);
+
+      datePicker.setConverter(new StringConverter<>() {
+         @Override
+         public String toString(LocalDate date) {
+            return (date != null) ? formatter.format(date) : "";
+         }
+
+         @Override
+         public LocalDate fromString(String s) {
+            try {
+               return (s != null && !s.isEmpty()) ? LocalDate.parse(s, formatter) : null;
+            } catch (DateTimeParseException e) {
+               return null;
+            }
+         }
+      });
+
+      datePicker.setPromptText(formatter.format(LocalDate.now()));
+   }
 }

--- a/src/main/java/de/doubleslash/keeptime/common/DateFormatter.java
+++ b/src/main/java/de/doubleslash/keeptime/common/DateFormatter.java
@@ -90,6 +90,7 @@ public class DateFormatter {
          }
       });
 
+      datePicker.setOnShowing(e -> Locale.setDefault(systemLocale));
       datePicker.setPromptText(formatter.format(LocalDate.now()));
    }
 }

--- a/src/main/java/de/doubleslash/keeptime/common/DateFormatter.java
+++ b/src/main/java/de/doubleslash/keeptime/common/DateFormatter.java
@@ -90,7 +90,9 @@ public class DateFormatter {
          }
       });
 
-      datePicker.setOnShowing(e -> Locale.setDefault(systemLocale));
+      datePicker.setOnShowing(e-> Locale.setDefault(Locale.Category.FORMAT, systemLocale));
+      datePicker.setOnHiding(e-> Locale.setDefault(Locale.Category.FORMAT, Locale.getDefault()));
+      datePicker.setOnAction(e-> Locale.setDefault(Locale.Category.FORMAT, Locale.getDefault()));
       datePicker.setPromptText(formatter.format(LocalDate.now()));
    }
 }

--- a/src/main/java/de/doubleslash/keeptime/common/DateFormatter.java
+++ b/src/main/java/de/doubleslash/keeptime/common/DateFormatter.java
@@ -31,7 +31,7 @@ public class DateFormatter {
    private static DateTimeFormatter dayDateFormatter = DateTimeFormatter.ofPattern("eeee dd.MM.yyyy");
    private static DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("HH:mm:ss");
 
-   private static Locale systemLocale = Locale.GERMAN;
+   private static Locale systemLocale = Locale.getDefault();
 
    private DateFormatter() {
       throw new IllegalStateException("Utility class: DateFormatter");

--- a/src/main/java/de/doubleslash/keeptime/view/ExternalProjectsSyncController.java
+++ b/src/main/java/de/doubleslash/keeptime/view/ExternalProjectsSyncController.java
@@ -124,7 +124,9 @@ public class ExternalProjectsSyncController {
    private final Color colorLoadingSuccess = Color.valueOf("#74a317");
    private final Color colorLoadingFailure = Color.valueOf("#c63329");
 
-   private final LocalTimeStringConverter localTimeStringConverter = new LocalTimeStringConverter(FormatStyle.MEDIUM);
+   private final LocalTimeStringConverter localTimeStringConverter = new LocalTimeStringConverter(
+         FormatStyle.MEDIUM,
+         DateFormatter.getSystemLocale());
    private ObservableList<TableRow> items;
 
    private LocalDate currentReportDate;
@@ -579,8 +581,10 @@ public class ExternalProjectsSyncController {
    }
 
    private void setUpTimeSpinner(final Spinner<LocalTime> spinner) {
+      final LocalTimeStringConverter stringConverter = new LocalTimeStringConverter(
+            FormatStyle.MEDIUM,
+            DateFormatter.getSystemLocale());
       spinner.focusedProperty().addListener(e -> {
-         final LocalTimeStringConverter stringConverter = new LocalTimeStringConverter(FormatStyle.MEDIUM);
          final StringProperty text = spinner.getEditor().textProperty();
          try {
             stringConverter.fromString(text.get());
@@ -621,7 +625,7 @@ public class ExternalProjectsSyncController {
 
       });
 
-      spinner.getValueFactory().setConverter(new LocalTimeStringConverter(FormatStyle.MEDIUM));
+      spinner.getValueFactory().setConverter(stringConverter);
    }
 
    public static LocalTime decrementToLastFullQuarter(LocalTime time) {

--- a/src/main/java/de/doubleslash/keeptime/view/ManageWorkController.java
+++ b/src/main/java/de/doubleslash/keeptime/view/ManageWorkController.java
@@ -21,6 +21,7 @@ import java.time.LocalTime;
 import java.time.format.DateTimeParseException;
 import java.time.format.FormatStyle;
 
+import de.doubleslash.keeptime.common.DateFormatter;
 import javafx.scene.control.skin.ComboBoxListViewSkin;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -120,6 +121,9 @@ public class ManageWorkController {
 
    private void setUpTimeRestriction() {
 
+      DateFormatter.applySystemLocaleOnDate(startDatePicker);
+      DateFormatter.applySystemLocaleOnDate(endDatePicker);
+
       BooleanBinding isValidBinding = Bindings.createBooleanBinding(() -> {
          if (startTimeSpinner.getValue() == null || endTimeSpinner.getValue() == null
                || startDatePicker.getValue() == null || endDatePicker.getValue() == null) {
@@ -150,8 +154,11 @@ public class ManageWorkController {
    }
 
    private void setUpTimeSpinner(final Spinner<LocalTime> spinner) {
+      final LocalTimeStringConverter stringConverter = new LocalTimeStringConverter(
+            FormatStyle.MEDIUM,
+            DateFormatter.getSystemLocale()
+            );
       spinner.focusedProperty().addListener((e) -> {
-         final LocalTimeStringConverter stringConverter = new LocalTimeStringConverter(FormatStyle.MEDIUM);
          final StringProperty text = spinner.getEditor().textProperty();
          try {
             stringConverter.fromString(text.get());
@@ -188,7 +195,7 @@ public class ManageWorkController {
 
       });
 
-      spinner.getValueFactory().setConverter(new LocalTimeStringConverter(FormatStyle.MEDIUM));
+      spinner.getValueFactory().setConverter(stringConverter);
 
    }
 

--- a/src/main/java/de/doubleslash/keeptime/view/ReportController.java
+++ b/src/main/java/de/doubleslash/keeptime/view/ReportController.java
@@ -361,9 +361,7 @@ public class ReportController {
          updateReport(newvalue);
       });
 
-      // HACK to show calendar from datepicker
-      // https://stackoverflow.com/questions/34681975/javafx-extract-calendar-popup-from-datepicker-only-show-popup
-      final DatePickerSkin datePickerSkin = new DatePickerSkin(myDatePicker);
+
       final Callback<DatePicker, DateCell> dayCellFactory = callback -> new DateCell() {
          @Override
          public void updateItem(final LocalDate item, final boolean empty) {
@@ -379,9 +377,19 @@ public class ReportController {
 
       };
       myDatePicker.setDayCellFactory(dayCellFactory);
-      final Node popupContent = datePickerSkin.getPopupContent();
-      this.topBorderPane.setRight(popupContent);
 
+      Locale defaultLocale = Locale.getDefault();
+      try {
+         Locale.setDefault(DateFormatter.getSystemLocale());
+
+         // HACK to show calendar from datepicker
+         // https://stackoverflow.com/questions/34681975/javafx-extract-calendar-popup-from-datepicker-only-show-popup
+         final DatePickerSkin datePickerSkin = new DatePickerSkin(myDatePicker);
+         final Node popupContent = datePickerSkin.getPopupContent();
+         this.topBorderPane.setRight(popupContent);
+      } finally {
+         Locale.setDefault(defaultLocale);
+      }
    }
 
    private Button createDeleteWorkButton(final Work w) {

--- a/src/main/java/de/doubleslash/keeptime/view/ReportController.java
+++ b/src/main/java/de/doubleslash/keeptime/view/ReportController.java
@@ -355,6 +355,7 @@ public class ReportController {
 
    private void loadCalenderWidget() {
       final DatePicker myDatePicker = new DatePicker(this.currentReportDate);
+      DateFormatter.applySystemLocaleOnDate(myDatePicker);
       myDatePicker.valueProperty().addListener((observable, oldvalue, newvalue) -> {
          LOG.info("Datepicker selected value changed to {}", newvalue);
          updateReport(newvalue);

--- a/src/test/java/de/doubleslash/keeptime/common/DateFormatterTest.java
+++ b/src/test/java/de/doubleslash/keeptime/common/DateFormatterTest.java
@@ -18,11 +18,16 @@ package de.doubleslash.keeptime.common;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Locale;
 
+import javafx.scene.control.DatePicker;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Disabled
 class DateFormatterTest {
@@ -37,5 +42,22 @@ class DateFormatterTest {
 
       final long secondsBewtweenSwitched = DateFormatter.getSecondsBewtween(endDate, startDate);
       assertThat(secondsBewtweenSwitched, Matchers.is(0l)); // why??
+   }
+
+   @Test
+   void applySystemLocaleShouldSetDatePickerLocale() {
+      // GIVEN
+      Locale.setDefault(Locale.ENGLISH);
+      DateFormatter.setSystemLocale(Locale.GERMAN);
+      DatePicker datePicker = new DatePicker();
+      LocalDate date = LocalDate.of(2024, 6, 3);
+
+      // WHEN
+      DateFormatter.applySystemLocaleOnDate(datePicker);
+      datePicker.setValue(date);
+
+      // THEN
+      String shown = datePicker.getEditor().getText();
+      assertTrue(shown.contains("Montag") || shown.contains("06.2024") || shown.contains("06"));
    }
 }

--- a/src/test/java/de/doubleslash/keeptime/common/DateFormatterTest.java
+++ b/src/test/java/de/doubleslash/keeptime/common/DateFormatterTest.java
@@ -43,25 +43,4 @@ class DateFormatterTest {
       final long secondsBewtweenSwitched = DateFormatter.getSecondsBewtween(endDate, startDate);
       assertThat(secondsBewtweenSwitched, Matchers.is(0l)); // why??
    }
-
-   @Test
-   void applySystemLocaleShouldSetDatePickerLocale() {
-      // GIVEN
-      Locale defaultLocale = Locale.getDefault();
-      Locale.setDefault(Locale.ENGLISH);
-      DateFormatter.setSystemLocale(Locale.GERMAN);
-      DatePicker datePicker = new DatePicker();
-      LocalDate date = LocalDate.of(2024, 6, 3);
-
-      // WHEN
-      DateFormatter.applySystemLocaleOnDate(datePicker);
-      datePicker.setValue(date);
-
-      // THEN
-      String shown = datePicker.getEditor().getText();
-      assertTrue(shown.contains("Montag"));
-      assertTrue(shown.contains("06.2024"));
-
-      Locale.setDefault(defaultLocale);
-   }
 }

--- a/src/test/java/de/doubleslash/keeptime/common/DateFormatterTest.java
+++ b/src/test/java/de/doubleslash/keeptime/common/DateFormatterTest.java
@@ -47,6 +47,7 @@ class DateFormatterTest {
    @Test
    void applySystemLocaleShouldSetDatePickerLocale() {
       // GIVEN
+      Locale defaultLocale = Locale.getDefault();
       Locale.setDefault(Locale.ENGLISH);
       DateFormatter.setSystemLocale(Locale.GERMAN);
       DatePicker datePicker = new DatePicker();
@@ -58,6 +59,9 @@ class DateFormatterTest {
 
       // THEN
       String shown = datePicker.getEditor().getText();
-      assertTrue(shown.contains("Montag") || shown.contains("06.2024") || shown.contains("06"));
+      assertTrue(shown.contains("Montag"));
+      assertTrue(shown.contains("06.2024"));
+
+      Locale.setDefault(defaultLocale);
    }
 }


### PR DESCRIPTION
**Locale management and formatting improvements:**

* Added `setSystemLocale`, `getSystemLocale`, and `applySystemLocaleOnDate` methods to the `DateFormatter` utility class, allowing centralized management of the application's locale and consistent formatting of dates in `DatePicker` components. (`DateFormatter.java`) [[1]](diffhunk://#diff-1ac6d1ddce45b73b20d37f63df7255a262a07f302ee53ae8d976cf42883978abR19-R35) [[2]](diffhunk://#diff-1ac6d1ddce45b73b20d37f63df7255a262a07f302ee53ae8d976cf42883978abR66-R94)
* On application startup, the system locale is now set in `DateFormatter`, and the default locale is explicitly set to English to ensure predictable behavior. (`App.java`) [[1]](diffhunk://#diff-3439823e632a1b7d0d15b927980d2db5b02f094cedbf4ab438615f761a83d84cR24-R28) [[2]](diffhunk://#diff-3439823e632a1b7d0d15b927980d2db5b02f094cedbf4ab438615f761a83d84cR89-R90)