### PR TITLE
#188: Add Ability to Manually Add Work Entries

### DIFF
--- a/src/main/java/de/doubleslash/keeptime/controller/Controller.java
+++ b/src/main/java/de/doubleslash/keeptime/controller/Controller.java
@@ -272,6 +272,17 @@ public class Controller {
       model.getWorkRepository().delete(workToBeDeleted);
    }
 
+   public Work addWork(final Work work) {
+      LOG.info("Adding work '{}'", work);
+      final Work saved = model.getWorkRepository().save(work);
+      // show in report if it belongs to today
+      final LocalDate today = dateProvider.dateTimeNow().toLocalDate();
+      if (today.equals(saved.getStartTime().toLocalDate())) {
+         model.getPastWorkItems().add(saved);
+      }
+      return saved;
+   }
+
    /**
     * Changes the indexes of the originalList parameter to have a consistent order.
     *

--- a/src/main/java/de/doubleslash/keeptime/view/ManageWorkController.java
+++ b/src/main/java/de/doubleslash/keeptime/view/ManageWorkController.java
@@ -17,9 +17,6 @@
 package de.doubleslash.keeptime.view;
 
 import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.time.format.DateTimeParseException;
-import java.time.format.FormatStyle;
 
 import javafx.scene.control.skin.ComboBoxListViewSkin;
 import org.slf4j.Logger;
@@ -35,7 +32,6 @@ import javafx.beans.binding.Bindings;
 import javafx.beans.binding.BooleanBinding;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
-import javafx.beans.property.StringProperty;
 import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
 import javafx.collections.transformation.FilteredList;
@@ -46,8 +42,6 @@ import javafx.scene.control.DatePicker;
 import javafx.scene.control.Label;
 import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
-import javafx.scene.control.Spinner;
-import javafx.scene.control.SpinnerValueFactory;
 import javafx.scene.control.TextArea;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyCodeCombination;
@@ -55,7 +49,6 @@ import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.GridPane;
 import javafx.scene.paint.Color;
 import javafx.util.StringConverter;
-import javafx.util.converter.LocalTimeStringConverter;
 
 public class ManageWorkController {
 
@@ -70,10 +63,10 @@ public class ManageWorkController {
    private DatePicker startDatePicker;
 
    @FXML
-   private Spinner<LocalTime> startTimeSpinner;
+   private TimePickerComboBox startTimePicker;
 
    @FXML
-   private Spinner<LocalTime> endTimeSpinner;
+   private TimePickerComboBox endTimePicker;
 
    @FXML
    private DatePicker endDatePicker;
@@ -102,10 +95,6 @@ public class ManageWorkController {
    @FXML
    private void initialize() {
 
-      setUpTimeSpinner(startTimeSpinner);
-
-      setUpTimeSpinner(endTimeSpinner);
-
       setUpTimeRestriction();
 
       setProjectUpComboBox();
@@ -121,20 +110,20 @@ public class ManageWorkController {
    private void setUpTimeRestriction() {
 
       BooleanBinding isValidBinding = Bindings.createBooleanBinding(() -> {
-         if (startTimeSpinner.getValue() == null || endTimeSpinner.getValue() == null
+         if (startTimePicker.getValue() == null || endTimePicker.getValue() == null
                || startDatePicker.getValue() == null || endDatePicker.getValue() == null) {
             return false;
          }
 
-         LocalDateTime start = LocalDateTime.of(startDatePicker.getValue(), startTimeSpinner.getValue());
-         LocalDateTime end = LocalDateTime.of(endDatePicker.getValue(), endTimeSpinner.getValue());
+         LocalDateTime start = LocalDateTime.of(startDatePicker.getValue(), startTimePicker.getValue());
+         LocalDateTime end = LocalDateTime.of(endDatePicker.getValue(), endTimePicker.getValue());
 
          if (start.isAfter(end)) {
             return false;
          } else {
             return true;
          }
-      }, startTimeSpinner.valueProperty(), endTimeSpinner.valueProperty(), endDatePicker.valueProperty(),
+   }, startTimePicker.valueProperty(), endTimePicker.valueProperty(), endDatePicker.valueProperty(),
             startDatePicker.valueProperty());
 
       this.isValidProperty.bind(isValidBinding);
@@ -149,48 +138,6 @@ public class ManageWorkController {
       }, isValidProperty));
    }
 
-   private void setUpTimeSpinner(final Spinner<LocalTime> spinner) {
-      spinner.focusedProperty().addListener((e) -> {
-         final LocalTimeStringConverter stringConverter = new LocalTimeStringConverter(FormatStyle.MEDIUM);
-         final StringProperty text = spinner.getEditor().textProperty();
-         try {
-            stringConverter.fromString(text.get());
-            // needed to log in value from editor to spinner
-            spinner.increment(0); // TODO find better Solution
-         } catch (final DateTimeParseException ex) {
-            text.setValue(spinner.getValue().toString());
-         }
-      });
-
-      spinner.setValueFactory(new SpinnerValueFactory<LocalTime>() {
-
-         @Override
-         public void decrement(final int steps) {
-            if (getValue() == null) {
-               setValue(LocalTime.now());
-            } else {
-               final LocalTime time = getValue();
-               setValue(time.minusMinutes(steps));
-            }
-
-         }
-
-         @Override
-         public void increment(final int steps) {
-            if (getValue() == null) {
-               setValue(LocalTime.now());
-            } else {
-               final LocalTime time = getValue();
-               setValue(time.plusMinutes(steps));
-            }
-
-         }
-
-      });
-
-      spinner.getValueFactory().setConverter(new LocalTimeStringConverter(FormatStyle.MEDIUM));
-
-   }
 
    private void setProjectUpComboBox() {
       // color Dropdown Options
@@ -330,8 +277,8 @@ public class ManageWorkController {
       startDatePicker.setValue(work.getStartTime().toLocalDate());
       endDatePicker.setValue(work.getEndTime().toLocalDate());
 
-      startTimeSpinner.getValueFactory().setValue(work.getStartTime().toLocalTime());
-      endTimeSpinner.getValueFactory().setValue(work.getEndTime().toLocalTime());
+      startTimePicker.setValue(work.getStartTime().toLocalTime());
+      endTimePicker.setValue(work.getEndTime().toLocalTime());
 
       noteTextArea.setText(work.getNotes());
 
@@ -366,8 +313,8 @@ public class ManageWorkController {
    }
 
    public Work getWorkFromUserInput() {
-      return new Work(LocalDateTime.of(startDatePicker.getValue(), startTimeSpinner.getValue()),
-            LocalDateTime.of(endDatePicker.getValue(), endTimeSpinner.getValue()), selectedProject,
+   return new Work(LocalDateTime.of(startDatePicker.getValue(), startTimePicker.getValue()),
+      LocalDateTime.of(endDatePicker.getValue(), endTimePicker.getValue()), selectedProject,
             noteTextArea.getText());
    }
 

--- a/src/main/java/de/doubleslash/keeptime/view/ReportController.java
+++ b/src/main/java/de/doubleslash/keeptime/view/ReportController.java
@@ -18,6 +18,8 @@ package de.doubleslash.keeptime.view;
 
 import java.io.IOException;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -102,6 +104,9 @@ public class ReportController {
    @FXML
    private Button heimatSyncButton;
 
+   @FXML
+   private Button addWorkButton;
+
    private static final Logger LOG = LoggerFactory.getLogger(ReportController.class);
 
    private final Model model;
@@ -132,8 +137,32 @@ public class ReportController {
       colorTimeLine = new ColorTimeLine(colorTimeLineCanvas);
 
       expandCollapseButton.setOnMouseClicked(event ->toggleCollapseExpandReport());
+      if (addWorkButton != null) {
+         addWorkButton.setOnAction(e -> onAddWork());
+      }
       initTableView();
       initHeimatIntegration();
+   }
+
+   private void onAddWork() {
+      // Default values: current report date window or now if today
+      final boolean isToday = LocalDate.now().equals(currentReportDate);
+      final LocalDateTime now = LocalDateTime.now();
+      final LocalDateTime defaultStart = isToday ? now.minusMinutes(15) : currentReportDate.atTime(LocalTime.of(9, 0));
+      final LocalDateTime defaultEnd = isToday ? now : currentReportDate.atTime(LocalTime.of(10, 0));
+
+      final Project defaultProject = model.activeWorkItem.get() != null
+            ? model.activeWorkItem.get().getProject()
+            : model.getIdleProject();
+
+      final Work newWorkDefaults = new Work(defaultStart, defaultEnd, defaultProject, "");
+      final Dialog<Work> dialog = setupAddWorkDialog(newWorkDefaults);
+
+      final Optional<Work> result = dialog.showAndWait();
+      result.ifPresent(createdWork -> {
+         controller.addWork(createdWork);
+         this.update();
+      });
    }
 
    private void initHeimatIntegration() {
@@ -440,6 +469,19 @@ public class ReportController {
       dialog.initOwner(stage);
       dialog.setTitle(EDIT_WORK_DIALOG_TITLE);
       dialog.setHeaderText(EDIT_WORK_DIALOG_TITLE);
+      dialog.getDialogPane().getButtonTypes().addAll(ButtonType.OK, ButtonType.CANCEL);
+
+      final GridPane grid = setUpEditWorkGridPane(work, dialog);
+      dialog.getDialogPane().setContent(grid);
+
+      return dialog;
+   }
+
+   private Dialog<Work> setupAddWorkDialog(final Work work) {
+      final Dialog<Work> dialog = new Dialog<>();
+      dialog.initOwner(stage);
+      dialog.setTitle("Add work");
+      dialog.setHeaderText("Add work");
       dialog.getDialogPane().getButtonTypes().addAll(ButtonType.OK, ButtonType.CANCEL);
 
       final GridPane grid = setUpEditWorkGridPane(work, dialog);

--- a/src/main/java/de/doubleslash/keeptime/view/TimePickerComboBox.java
+++ b/src/main/java/de/doubleslash/keeptime/view/TimePickerComboBox.java
@@ -1,0 +1,116 @@
+package de.doubleslash.keeptime.view;
+
+import javafx.application.Platform;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.scene.control.ComboBox;
+import javafx.scene.control.Label;
+import javafx.scene.layout.HBox;
+import javafx.util.StringConverter;
+
+import java.time.LocalTime;
+import java.util.stream.IntStream;
+
+public class TimePickerComboBox extends HBox {
+
+   private final ComboBox<Integer> hourBox = new ComboBox<>();
+   private final ComboBox<Integer> minuteBox = new ComboBox<>();
+
+   private final ObjectProperty<LocalTime> value = new SimpleObjectProperty<>(this, "value");
+
+   private boolean updating = false;
+
+   public TimePickerComboBox() {
+      init24HourControls();
+      attachListeners();
+      setSpacing(4);
+   }
+
+   public ObjectProperty<LocalTime> valueProperty() {
+      return value;
+   }
+
+   public LocalTime getValue() {
+      return value.get();
+   }
+
+   public void setValue(LocalTime time) {
+      value.set(time);
+   }
+
+   private void attachListeners() {
+      hourBox.valueProperty().addListener((obs, ov, nv) -> updateValueFromUi());
+      minuteBox.valueProperty().addListener((obs, ov, nv) -> updateValueFromUi());
+      value.addListener((obs, ov, nv) -> updateUiFromValue(nv));
+   }
+
+   private void init24HourControls() {
+      // Populate hours 0-23
+      hourBox.getItems().setAll(IntStream.range(0, 24).boxed().toList());
+      // Populate minutes 0-59
+      minuteBox.getItems().setAll(IntStream.range(0, 60).boxed().toList());
+
+      // Two-digit formatting for hour/minute
+      StringConverter<Integer> twoDigitConverter = new StringConverter<>() {
+         @Override public String toString(Integer object) {
+            return object == null ? "" : String.format("%02d", object);
+         }
+         @Override public Integer fromString(String string) {
+            try { return Integer.valueOf(string); } catch (Exception e) { return null; }
+         }
+      };
+      hourBox.setConverter(twoDigitConverter);
+      minuteBox.setConverter(twoDigitConverter);
+      // Ensure editors exist for formatting updates
+      hourBox.setEditable(true);
+      minuteBox.setEditable(true);
+
+      getChildren().clear();
+      getChildren().addAll(hourBox, new Label(":"), minuteBox);
+   }
+
+   private void updateValueFromUi() {
+      if (updating) return;
+
+      Integer hSel = hourBox.getValue();
+      Integer mSel = minuteBox.getValue();
+      if (hSel == null || mSel == null) {
+         value.set(null);
+         return;
+      }
+
+      int hour24 = hSel;
+
+      updating = true;
+      try {
+         value.set(LocalTime.of(hour24, mSel));
+      } finally {
+         updating = false;
+      }
+   }
+
+   private void updateUiFromValue(LocalTime t) {
+      if (updating) return;
+
+      updating = true;
+      try {
+         if (t == null) {
+            hourBox.getSelectionModel().clearSelection();
+            minuteBox.getSelectionModel().clearSelection();
+            return;
+         }
+
+         int h24 = t.getHour();
+         int m = t.getMinute();
+         hourBox.setValue(h24);
+         minuteBox.setValue(m);
+
+         Platform.runLater(() -> {
+            minuteBox.getEditor().setText(minuteBox.getConverter().toString(minuteBox.getValue()));
+            hourBox.getEditor().setText(hourBox.getConverter().toString(hourBox.getValue()));
+         });
+      } finally {
+         updating = false;
+      }
+   }
+}

--- a/src/main/resources/layouts/manage-work.fxml
+++ b/src/main/resources/layouts/manage-work.fxml
@@ -11,62 +11,65 @@
 <?import javafx.scene.text.Font?>
 <?import de.doubleslash.keeptime.view.TimePickerComboBox?>
 
-<GridPane fx:id="grid" hgap="5.0" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="214.0" prefWidth="371.0" vgap="5.0" xmlns="http://javafx.com/javafx/8.0.171" xmlns:fx="http://javafx.com/fxml/1" fx:controller="de.doubleslash.keeptime.view.ManageWorkController">
-  <columnConstraints>
-    <ColumnConstraints hgrow="SOMETIMES" />
-    <ColumnConstraints hgrow="SOMETIMES" maxWidth="200.0" minWidth="100.0" prefWidth="150.0" />
-    <ColumnConstraints hgrow="SOMETIMES" maxWidth="200.0" minWidth="100.0" prefWidth="150.0" />
-  </columnConstraints>
-  <rowConstraints>
-    <RowConstraints vgrow="SOMETIMES" />
-    <RowConstraints vgrow="SOMETIMES" />
-    <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-    <RowConstraints vgrow="SOMETIMES" />
-    <RowConstraints vgrow="SOMETIMES" />
-      <RowConstraints />
-  </rowConstraints>
-  <children>
+<GridPane fx:id="grid" hgap="5.0" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity"
+          prefHeight="214.0" prefWidth="371.0" vgap="5.0" xmlns="http://javafx.com/javafx/8.0.171"
+          xmlns:fx="http://javafx.com/fxml/1" fx:controller="de.doubleslash.keeptime.view.ManageWorkController">
+    <columnConstraints>
+        <ColumnConstraints hgrow="SOMETIMES"/>
+        <ColumnConstraints hgrow="SOMETIMES" maxWidth="200.0" minWidth="100.0" prefWidth="150.0"/>
+        <ColumnConstraints hgrow="SOMETIMES" maxWidth="200.0" minWidth="100.0" prefWidth="150.0"/>
+    </columnConstraints>
+    <rowConstraints>
+        <RowConstraints vgrow="SOMETIMES"/>
+        <RowConstraints vgrow="SOMETIMES"/>
+        <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES"/>
+        <RowConstraints vgrow="SOMETIMES"/>
+        <RowConstraints vgrow="SOMETIMES"/>
+        <RowConstraints/>
+    </rowConstraints>
+    <padding>
+        <Insets bottom="5.0" left="5.0" right="5.0" top="5.0"/>
+    </padding>
     <Label text="Start">
-      <font>
-        <Font name="Open Sans Regular" size="12.0" />
-      </font>
+        <font>
+            <Font name="Open Sans Regular" size="12.0"/>
+        </font>
     </Label>
-  <DatePicker fx:id="startDatePicker" GridPane.columnIndex="1" />
-  <TimePickerComboBox fx:id="startTimePicker" GridPane.columnIndex="2" />
+    <DatePicker fx:id="startDatePicker" GridPane.columnIndex="1"/>
+    <TimePickerComboBox fx:id="startTimePicker" GridPane.columnIndex="2"/>
     <Label text="End" GridPane.rowIndex="1">
-      <font>
-        <Font name="Open Sans Regular" size="12.0" />
-      </font>
+        <font>
+            <Font name="Open Sans Regular" size="12.0"/>
+        </font>
     </Label>
-  <DatePicker fx:id="endDatePicker" GridPane.columnIndex="1" GridPane.rowIndex="1" />
-  <TimePickerComboBox fx:id="endTimePicker" GridPane.columnIndex="2" GridPane.rowIndex="1" />
+    <DatePicker fx:id="endDatePicker" GridPane.columnIndex="1" GridPane.rowIndex="1"/>
+    <TimePickerComboBox fx:id="endTimePicker" GridPane.columnIndex="2" GridPane.rowIndex="1"/>
     <Label text="Project" GridPane.rowIndex="3">
-      <font>
-        <Font name="Open Sans Regular" size="12.0" />
-      </font>
+        <font>
+            <Font name="Open Sans Regular" size="12.0"/>
+        </font>
     </Label>
-    <ComboBox fx:id="projectComboBox" editable="true" prefWidth="400.0" visibleRowCount="4" GridPane.columnIndex="1" GridPane.columnSpan="2" GridPane.rowIndex="3" />
+    <ComboBox fx:id="projectComboBox" editable="true" prefWidth="400.0" visibleRowCount="4" GridPane.columnIndex="1"
+              GridPane.columnSpan="2" GridPane.rowIndex="3"/>
     <Label text="Notes" GridPane.rowIndex="4">
-      <font>
-        <Font name="Open Sans Regular" size="12.0" />
-      </font>
+        <font>
+            <Font name="Open Sans Regular" size="12.0"/>
+        </font>
     </Label>
-    <TextArea fx:id="noteTextArea" prefHeight="200.0" prefWidth="200.0" wrapText="true" GridPane.columnIndex="1" GridPane.columnSpan="2" GridPane.rowIndex="4" />
-    <Label text="Changing the times may result in overlapping times!" textFill="#ffa100" GridPane.columnIndex="1" GridPane.columnSpan="2" GridPane.rowIndex="2">
-      <font>
-        <Font name="Open Sans Regular" size="12.0" />
-      </font>
-      <GridPane.margin>
-        <Insets bottom="5.0" />
-      </GridPane.margin>
+    <TextArea fx:id="noteTextArea" prefHeight="200.0" prefWidth="200.0" wrapText="true" GridPane.columnIndex="1"
+              GridPane.columnSpan="2" GridPane.rowIndex="4"/>
+    <Label text="Changing the times may result in overlapping times!" textFill="#ffa100" GridPane.columnIndex="1"
+           GridPane.columnSpan="2" GridPane.rowIndex="2">
+        <font>
+            <Font name="Open Sans Regular" size="12.0"/>
+        </font>
+        <GridPane.margin>
+            <Insets bottom="5.0"/>
+        </GridPane.margin>
     </Label>
-      <Label fx:id="errorLabel" textFill="RED" GridPane.columnIndex="1" GridPane.columnSpan="2" GridPane.rowIndex="5">
-         <font>
-            <Font name="Open Sans Regular" size="12.0" />
-         </font>
-      </Label>
-  </children>
-  <padding>
-    <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
-  </padding>
+    <Label fx:id="errorLabel" textFill="RED" GridPane.columnIndex="1" GridPane.columnSpan="2" GridPane.rowIndex="5">
+        <font>
+          <Font name="Open Sans Regular" size="12.0"/>
+        </font>
+    </Label>
 </GridPane>

--- a/src/main/resources/layouts/manage-work.fxml
+++ b/src/main/resources/layouts/manage-work.fxml
@@ -4,12 +4,12 @@
 <?import javafx.scene.control.ComboBox?>
 <?import javafx.scene.control.DatePicker?>
 <?import javafx.scene.control.Label?>
-<?import javafx.scene.control.Spinner?>
 <?import javafx.scene.control.TextArea?>
 <?import javafx.scene.layout.ColumnConstraints?>
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.text.Font?>
+<?import de.doubleslash.keeptime.view.TimePickerComboBox?>
 
 <GridPane fx:id="grid" hgap="5.0" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="214.0" prefWidth="371.0" vgap="5.0" xmlns="http://javafx.com/javafx/8.0.171" xmlns:fx="http://javafx.com/fxml/1" fx:controller="de.doubleslash.keeptime.view.ManageWorkController">
   <columnConstraints>
@@ -31,15 +31,15 @@
         <Font name="Open Sans Regular" size="12.0" />
       </font>
     </Label>
-    <DatePicker fx:id="startDatePicker" GridPane.columnIndex="1" />
-    <Spinner fx:id="startTimeSpinner" editable="true" GridPane.columnIndex="2" />
+  <DatePicker fx:id="startDatePicker" GridPane.columnIndex="1" />
+  <TimePickerComboBox fx:id="startTimePicker" GridPane.columnIndex="2" />
     <Label text="End" GridPane.rowIndex="1">
       <font>
         <Font name="Open Sans Regular" size="12.0" />
       </font>
     </Label>
-    <DatePicker fx:id="endDatePicker" GridPane.columnIndex="1" GridPane.rowIndex="1" />
-    <Spinner fx:id="endTimeSpinner" editable="true" GridPane.columnIndex="2" GridPane.rowIndex="1" />
+  <DatePicker fx:id="endDatePicker" GridPane.columnIndex="1" GridPane.rowIndex="1" />
+  <TimePickerComboBox fx:id="endTimePicker" GridPane.columnIndex="2" GridPane.rowIndex="1" />
     <Label text="Project" GridPane.rowIndex="3">
       <font>
         <Font name="Open Sans Regular" size="12.0" />

--- a/src/main/resources/layouts/report.fxml
+++ b/src/main/resources/layouts/report.fxml
@@ -82,18 +82,15 @@
             </BorderPane>
             <BorderPane>
                <left>
-                  <Button fx:id="expandCollapseButton" mnemonicParsing="false" prefHeight="25.0" prefWidth="80.0" styleClass="secondary-button" text="Collapse" />
+                   <HBox spacing="5.0">
+                       <children>
+                           <Button fx:id="expandCollapseButton" mnemonicParsing="false" prefHeight="25.0" prefWidth="80.0" styleClass="secondary-button" text="Collapse" />
+                           <Button fx:id="addWorkButton" mnemonicParsing="false" prefHeight="25.0" prefWidth="80.0" styleClass="secondary-button" text="Add Work" />
+                    </children>
+                   </HBox>
                </left>
                <right>
-                  <HBox spacing="5.0">
-                     <children>
-                        <Button fx:id="addWorkButton" mnemonicParsing="false" styleClass="secondary-button" text="✚" textAlignment="CENTER">
-                           <font>
-                              <Font size="11.0" />
-                           </font></Button>
                         <Button fx:id="heimatSyncButton" mnemonicParsing="false" styleClass="secondary-button" text="Sync2Heimat" />
-                     </children>
-                  </HBox>
                </right>
                <padding>
                   <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />

--- a/src/main/resources/layouts/report.fxml
+++ b/src/main/resources/layouts/report.fxml
@@ -16,18 +16,13 @@
  You should have received a copy of the GNU General Public License
  along with this program. If not, see <http://www.gnu.org/licenses/>. -->
 
-<?import javafx.geometry.Insets?>
-<?import javafx.scene.canvas.Canvas?>
-<?import javafx.scene.control.Button?>
-<?import javafx.scene.control.Label?>
-<?import javafx.scene.control.TreeTableView?>
-<?import javafx.scene.layout.AnchorPane?>
-<?import javafx.scene.layout.BorderPane?>
-<?import javafx.scene.layout.HBox?>
-<?import javafx.scene.layout.VBox?>
-<?import javafx.scene.text.Font?>
+<?import javafx.geometry.*?>
+<?import javafx.scene.canvas.*?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
+<?import javafx.scene.text.*?>
 
-<AnchorPane fx:id="reportRoot" focusTraversable="true" prefWidth="500.0" style="-fx-background-color: white;" stylesheets="@../css/dsStyles.css" xmlns="http://javafx.com/javafx/8.0.171" xmlns:fx="http://javafx.com/fxml/1" fx:controller="de.doubleslash.keeptime.view.ReportController">
+<AnchorPane fx:id="reportRoot" focusTraversable="true" prefWidth="500.0" style="-fx-background-color: white;" stylesheets="@../css/dsStyles.css" xmlns="http://javafx.com/javafx/17.0.12" xmlns:fx="http://javafx.com/fxml/1" fx:controller="de.doubleslash.keeptime.view.ReportController">
    <children>
       <VBox>
          <children>
@@ -90,7 +85,15 @@
                   <Button fx:id="expandCollapseButton" mnemonicParsing="false" prefHeight="25.0" prefWidth="80.0" styleClass="secondary-button" text="Collapse" />
                </left>
                <right>
-                  <Button fx:id="heimatSyncButton" mnemonicParsing="false" styleClass="secondary-button" text="Sync2Heimat" />
+                  <HBox spacing="5.0">
+                     <children>
+                        <Button fx:id="addWorkButton" mnemonicParsing="false" styleClass="secondary-button" text="✚" textAlignment="CENTER">
+                           <font>
+                              <Font size="11.0" />
+                           </font></Button>
+                        <Button fx:id="heimatSyncButton" mnemonicParsing="false" styleClass="secondary-button" text="Sync2Heimat" />
+                     </children>
+                  </HBox>
                </right>
                <padding>
                   <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />


### PR DESCRIPTION
Add the ability to add an "Add Work" button next to the Sync button in the report view. When the user clicks Add Work the Manage Work popup appears, allowing them to enter details for a new work entry. If the user confirms by pressing OK, the new work is saved and immediately shown in the report.

- The button uses the same Manage Work dialog as editing, so the user experience is consistent.
- The logic for saving is simple and reuses existing methods.
- Changed the style of the time picker in mange work menu for easier use. 