### PR TITLE
PTBAS-737: using consistent english language now - strategy 2

### DIFF
--- a/src/main/java/de/doubleslash/keeptime/App.java
+++ b/src/main/java/de/doubleslash/keeptime/App.java
@@ -21,6 +21,7 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -84,6 +85,9 @@ public class App extends Application {
    @Override
    public void init() throws Exception {
       LOG.info("Starting KeepTime.");
+
+      setLocaleToEnglish();
+
       final DefaultExceptionHandler defaultExceptionHandler = new DefaultExceptionHandler();
       defaultExceptionHandler.register();
 
@@ -100,6 +104,22 @@ public class App extends Application {
       settings = springContext.getBean(Settings.class);
       controller.enableAutoSave();
       model.setSpringContext(springContext);
+   }
+
+   private void setLocaleToEnglish() {
+      final Locale systemDefaultLocale = Locale.getDefault();
+      final Locale wantedApplicationLocale = Locale.ENGLISH;
+
+      if(systemDefaultLocale.getLanguage().equals(wantedApplicationLocale.getLanguage())){
+         LOG.debug("Application Locale already is '{}'. Nothing to do.", wantedApplicationLocale);
+         return;
+      }
+
+      LOG.info("Setting application Locale to '{}', was '{}'.", wantedApplicationLocale, systemDefaultLocale);
+      Locale.setDefault(wantedApplicationLocale);
+      Locale.setDefault(Locale.Category.DISPLAY, wantedApplicationLocale);
+      // keep system locale for format conversions (date, currency, numbers)
+      Locale.setDefault(Locale.Category.FORMAT, systemDefaultLocale);
    }
 
    @Override

--- a/src/main/java/de/doubleslash/keeptime/App.java
+++ b/src/main/java/de/doubleslash/keeptime/App.java
@@ -110,12 +110,12 @@ public class App extends Application {
       final Locale systemDefaultLocale = Locale.getDefault();
       final Locale wantedApplicationLocale = Locale.ENGLISH;
 
-      if(systemDefaultLocale.getLanguage().equals(wantedApplicationLocale.getLanguage())){
-         LOG.debug("Application Locale already is '{}'. Nothing to do.", wantedApplicationLocale);
+      if (systemDefaultLocale.getLanguage().equals(wantedApplicationLocale.getLanguage())) {
+         LOG.debug("Application locale already is '{}'. Nothing to do.", wantedApplicationLocale);
          return;
       }
 
-      LOG.info("Setting application Locale to '{}', was '{}'.", wantedApplicationLocale, systemDefaultLocale);
+      LOG.info("Setting application locale to '{}', was '{}'.", wantedApplicationLocale, systemDefaultLocale);
       Locale.setDefault(wantedApplicationLocale);
       Locale.setDefault(Locale.Category.DISPLAY, wantedApplicationLocale);
       // keep system locale for format conversions (date, currency, numbers)
@@ -137,12 +137,13 @@ public class App extends Application {
       }
    }
 
-   public static void showErrorDialogAndWait(String title, String header, String content, final Exception e, Window window) {
+   public static void showErrorDialogAndWait(String title, String header, String content, final Exception e,
+         Window window) {
       final Alert alert = new Alert(AlertType.ERROR);
       alert.setTitle(title);
       alert.setHeaderText(header);
       alert.setContentText(content);
-      if(window != null) {
+      if (window != null) {
          alert.initOwner(window);
       }
       final StringWriter sw = new StringWriter();


### PR DESCRIPTION
On application startup, the system Locale is now set to ENGLISH if language is not already ENGLISH. However, the Locale used for formatting e.g. dates is kept in Systems default Locale.